### PR TITLE
PATCH: Update mcp.ts remove dubly sendMcpMessage

### DIFF
--- a/exercises/04.interactive/02.solution.tools/app/utils/mcp.ts
+++ b/exercises/04.interactive/02.solution.tools/app/utils/mcp.ts
@@ -41,12 +41,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],


### PR DESCRIPTION
Extra copied function overload signature for 'link'