### PR TITLE
PATCH: Utils mcp.ts clean up

### DIFF
--- a/exercises/04.interactive/02.solution.tools/app/utils/mcp.ts
+++ b/exercises/04.interactive/02.solution.tools/app/utils/mcp.ts
@@ -41,12 +41,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],

--- a/exercises/04.interactive/03.problem.prompts/app/utils/mcp.ts
+++ b/exercises/04.interactive/03.problem.prompts/app/utils/mcp.ts
@@ -45,12 +45,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],

--- a/exercises/04.interactive/03.solution.prompts/app/utils/mcp.ts
+++ b/exercises/04.interactive/03.solution.prompts/app/utils/mcp.ts
@@ -48,12 +48,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],

--- a/exercises/05.advanced/01.problem.tool-results/app/utils/mcp.ts
+++ b/exercises/05.advanced/01.problem.tool-results/app/utils/mcp.ts
@@ -48,12 +48,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],

--- a/exercises/05.advanced/01.solution.tool-results/app/utils/mcp.ts
+++ b/exercises/05.advanced/01.solution.tool-results/app/utils/mcp.ts
@@ -48,12 +48,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],

--- a/exercises/05.advanced/02.problem.render-data/app/utils/mcp.ts
+++ b/exercises/05.advanced/02.problem.render-data/app/utils/mcp.ts
@@ -48,12 +48,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],

--- a/exercises/05.advanced/02.solution.render-data/app/utils/mcp.ts
+++ b/exercises/05.advanced/02.solution.render-data/app/utils/mcp.ts
@@ -48,12 +48,6 @@ function sendMcpMessage<Options extends MessageOptions>(
 	options?: Options,
 ): McpMessageReturnType<Options>
 
-function sendMcpMessage<Options extends MessageOptions>(
-	type: 'link',
-	payload: McpMessageTypes['link'],
-	options?: Options,
-): McpMessageReturnType<Options>
-
 function sendMcpMessage(
 	type: McpMessageType,
 	payload: McpMessageTypes[McpMessageType],


### PR DESCRIPTION
There are duplicates of the overload signature in mcp.ts

```typescript
function sendMcpMessage<Options extends MessageOptions>(
	type: 'link',
	payload: McpMessageTypes['link'],
	options?: Options,
): McpMessageReturnType<Options>
```

Cleaned this up so the diff tool no longer flags a missing dupe signature. Had to do this for the rest of the downstream  exercises' copied files.